### PR TITLE
Removed common-lang 2.3 dependency

### DIFF
--- a/libmobiletagging/build.gradle
+++ b/libmobiletagging/build.gradle
@@ -36,7 +36,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'commons-lang:commons-lang:2.3'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.1.0'


### PR DESCRIPTION
The dependency was not used specifically and has been reported to crash.